### PR TITLE
ページング変数の変数名修正

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -2,12 +2,12 @@
 
 class BooksController < ApplicationController
   before_action :set_book, only: [:show, :edit, :update, :destroy]
-  PER_PAGE_NUMBER = 5
+  PER_PAGE = 5
 
   # GET /books
   # GET /books.json
   def index
-    @books = Book.page(params[:page]).per(PER_PAGE_NUMBER)
+    @books = Book.page(params[:page]).per(PER_PAGE)
   end
 
   # GET /books/1


### PR DESCRIPTION
- [x] ページング変数名を`PER_PAGE`に修正いたしました。

「1ページあたり件数」を英語に翻訳して、翻訳を省略して`PER_PAGE_NUMBER`と変数名をつけました。駒形さんから直訳っぽくて変なので`PER_PAGE`で良いと思いますとアドバイスを受けて、私自身も`PER_PAGE`の方がスッキリしてて、意味も分かりやすくなると思い修正しました。
